### PR TITLE
replace second pulse call from RTC irq.

### DIFF
--- a/kernel/stm32/stm32_rtc.c
+++ b/kernel/stm32/stm32_rtc.c
@@ -4,16 +4,17 @@
     All rights reserved.
 */
 
-#include "stm32_rtc.h"
-#include "stm32_config.h"
+#include "../ksystime.h"
+#include "../kirq.h"
 #include "../../userspace/rtc.h"
-#include "stm32_exo_private.h"
-#include "sys_config.h"
 #include "../../userspace/sys.h"
 #include "../../userspace/time.h"
-#include "../kirq.h"
 #include "../../userspace/systime.h"
 #include "../../userspace/stdio.h"
+#include "stm32_exo_private.h"
+#include "stm32_rtc.h"
+#include "stm32_config.h"
+#include "sys_config.h"
 
 #if defined(STM32L0) || defined(STM32L1)
 #define RTC_EXTI_LINE                               20
@@ -42,8 +43,7 @@ void stm32_rtc_isr(int vector, void* param)
 #if defined(STM32L0) || defined(STM32L1)
     EXTI->PR |= (1 << RTC_EXTI_LINE);
 #endif
-
-    systime_second_pulse();
+    ksystime_second_pulse();
 }
 
 static inline void stm32_backup_on()


### PR DESCRIPTION
ksystime_second_pulse() will call instead of systime_second_pulse().

ksystime_second_pulse() function is straight call for system second pulse.
But system_second_pulse() use svc to call system second pulse.
On exodriver system svc case SVC_SYSTIME_SECOND_PULSE does not enabled.