### PR TITLE
Fix bmCommandType field in CCID TimeExtension request

### DIFF
--- a/example/sys_config.h
+++ b/example/sys_config.h
@@ -82,7 +82,7 @@
 
 //----------------------------- CCIDD class -------------------------------------------
 #define USBD_CCID_REMOVABLE_CARD                            0
-// CCID Time Extension request perion in ms. Set to 0 to disable
+// CCID Time Extension request period in ms. Set to 0 to disable
 #define USBD_CCID_WTX_TIMEOUT_MS                            2000
 // Multiplier sending in Time Extension ccid request. Parse ATR and see BWT formula from CCID Rev 1.1. Page 7 of 123 to count
 #define USBD_CCID_WTX_BWT_MP                                0x10

--- a/example/sys_config.h
+++ b/example/sys_config.h
@@ -82,7 +82,11 @@
 
 //----------------------------- CCIDD class -------------------------------------------
 #define USBD_CCID_REMOVABLE_CARD                            0
-#define USBD_CCID_WTX_TIMEOUT_MS                            1000
+// CCID Time Extension request perion in ms. Set to 0 to disable
+#define USBD_CCID_WTX_TIMEOUT_MS                            2000
+// Multiplier sending in Time Extension ccid request. Parse ATR and see BWT formula from CCID Rev 1.1. Page 7 of 123 to count
+#define USBD_CCID_WTX_BWT_MP                                0x10
+
 
 #define USBD_CCID_DEBUG_ERRORS                              0
 #define USBD_CCID_DEBUG_REQUESTS                            0

--- a/midware/usbd/ccidd.c
+++ b/midware/usbd/ccidd.c
@@ -120,7 +120,7 @@ static void ccidd_send_wtx(USBD* usbd, CCIDD* ccidd, uint8_t seq, uint8_t timeou
 {
     io_reset(ccidd->wtx_io);
     CCID_SLOT_STATUS* msg = io_data(ccidd->wtx_io);
-    msg->bMessageType = RDR_TO_PC_SLOT_STATUS;
+    msg->bMessageType = RDR_TO_PC_DATA_BLOCK;
     msg->dwLength = 0;
     msg->bSlot = 0;
     msg->bSeq = seq;
@@ -529,7 +529,7 @@ static inline void ccidd_card_wtx(USBD* usbd, CCIDD* ccidd)
 #if (USBD_CCID_DEBUG_REQUESTS)
     printf("CCIDD: WTX\n");
 #endif //USBD_CCID_DEBUG_REQUESTS
-    ccidd_send_wtx(usbd, ccidd, ccidd->seq, 0x10);
+    ccidd_send_wtx(usbd, ccidd, ccidd->seq, USBD_CCID_WTX_BWT_MP);
     timer_start_ms(ccidd->wtx_timer, USBD_CCID_WTX_TIMEOUT_MS);
 }
 #endif // USBD_CCID_WTX_TIMEOUT_MS


### PR DESCRIPTION
Fix ccid time extension command on Win10.
1) For win7 or 8 bmCommandType in Time extension request could be any (worked well with 81h, 80h and also 00h). Due to CCID Rev 1.1 response for PC_to_RDR_XfrBlock should be RDR_to_PC_DataBlock.
2) BWT multiplier in Time Extension request. Counted due to ATR params and WTX_TIMEOUT_MS. For cardless system can be set in maximum value - FFh.